### PR TITLE
fix: set up permissions in installer correctly

### DIFF
--- a/packaging/debian/postinst.in
+++ b/packaging/debian/postinst.in
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+echo "GOT HERE"
+
 # The permissions don't always get set quite right, so make the
 # program files executable here
 chmod +x "/usr/@CMAKE_INSTALL_BINDIR@/fluir"
@@ -12,10 +14,12 @@ chmod +x "/usr/@CMAKE_INSTALL_LIBEXECDIR@/fluir/editor-fe/fluir-editor-fe"
 # Setup permissions on chrome-sandbox
 SANDBOX_PATH="/usr/@CMAKE_INSTALL_LIBEXECDIR@/fluir/editor-fe/chrome-sandbox"
 
+echo "SETTING UI PERMISSIONS"
 if [ -f "$SANDBOX_PATH" ]; then
     chown root:root "$SANDBOX_PATH"
     chmod 4755 "$SANDBOX_PATH"
 fi
+echo "DONE"
 
 #DEBHELPER#
 

--- a/packaging/debian/postinst.in
+++ b/packaging/debian/postinst.in
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-echo "GOT HERE"
 
 # The permissions don't always get set quite right, so make the
 # program files executable here
@@ -14,12 +13,10 @@ chmod +x "/usr/@CMAKE_INSTALL_LIBEXECDIR@/fluir/editor-fe/fluir-editor-fe"
 # Setup permissions on chrome-sandbox
 SANDBOX_PATH="/usr/@CMAKE_INSTALL_LIBEXECDIR@/fluir/editor-fe/chrome-sandbox"
 
-echo "SETTING UI PERMISSIONS"
 if [ -f "$SANDBOX_PATH" ]; then
     chown root:root "$SANDBOX_PATH"
     chmod 4755 "$SANDBOX_PATH"
 fi
-echo "DONE"
 
 #DEBHELPER#
 

--- a/packaging/debian/postinst.in
+++ b/packaging/debian/postinst.in
@@ -9,6 +9,14 @@ chmod +x "/usr/@CMAKE_INSTALL_LIBEXECDIR@/fluir/fluir.vm"
 chmod +x "/usr/@CMAKE_INSTALL_LIBEXECDIR@/fluir/fluir-editor-be"
 chmod +x "/usr/@CMAKE_INSTALL_LIBEXECDIR@/fluir/editor-fe/fluir-editor-fe"
 
+# Setup permissions on chrome-sandbox
+SANDBOX_PATH="/usr/@CMAKE_INSTALL_LIBEXECDIR@/fluir/editor-fe/chrome-sandbox"
+
+if [ -f "$SANDBOX_PATH" ]; then
+    chown root:root "$SANDBOX_PATH"
+    chmod 4755 "$SANDBOX_PATH"
+fi
+
 #DEBHELPER#
 
 exit 0


### PR DESCRIPTION
## Description

Fixes a permissions issue in the installer where the editor couldn't run without manually setting permissions after install.

## Known limitations

* Only works on ubuntu