### PR TITLE
fix: Compiler crash on funcion with multiple sinks and return

### DIFF
--- a/compiler/src/frontend/ast_builder/function_builder.cpp
+++ b/compiler/src/frontend/ast_builder/function_builder.cpp
@@ -213,10 +213,6 @@ namespace fluir::fe {
 
   std::unordered_set<fluir::ID> FunctionAstBuilder::getSinkNodes() const {
     std::unordered_set<fluir::ID> sinkNodes;
-    if (pt_.output && pt_.output->ret) {
-      // The return value is a sink if it exists
-      sinkNodes.insert(pt_.output->ret->id);
-    }
     const auto& block = pt_.body;
 
     // Start with all Nodes in the block


### PR DESCRIPTION
## Description

Fixed an issue where the function AST builder would try to handle the return value twice if there were other sink nodes in a function, causing a crash in the compiler.
